### PR TITLE
Vuexの導入と、XSRFトークンをヘッダーに付与する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10159,6 +10159,12 @@
             "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
             "dev": true
         },
+        "vuex": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.0.tgz",
+            "integrity": "sha512-W74OO2vCJPs9/YjNjW8lLbj+jzT24waTo2KShI8jLvJW8OaIkgb3wuAMA7D+ZiUxDOx3ubwSZTaJBip9G8a3aQ==",
+            "dev": true
+        },
         "watchpack": {
             "version": "1.7.5",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "sass-loader": "^8.0.0",
         "vue": "^2.6.12",
         "vue-router": "^3.4.9",
-        "vue-template-compiler": "^2.6.12"
+        "vue-template-compiler": "^2.6.12",
+        "vuex": "^3.6.0"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import router from './router'
 import App from './App.vue'
+import './bootstrap'
 
 new Vue({
     el: '#app',

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,6 +5,7 @@ import App from './App.vue'
 new Vue({
     el: '#app',
     router,
+    store,
     components: { App },
     template: '<App />'
 })

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,28 +1,13 @@
-window._ = require('lodash');
-
-/**
- * We'll load the axios HTTP library which allows us to easily issue requests
- * to our Laravel back-end. This library automatically handles sending the
- * CSRF token as a header based on the value of the "XSRF" token cookie.
- */
+import { getCookieValue } from './util'
 
 window.axios = require('axios');
 
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+// Ajaxリクエストであることを示すヘッダーを付与する
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
 
-/**
- * Echo exposes an expressive API for subscribing to channels and listening
- * for events that are broadcast by Laravel. Echo and event broadcasting
- * allows your team to easily build robust real-time web applications.
- */
+window.axios.interceptors.request.use(config => {
+    // クッキーからトークンを取り出してヘッダーに添付する
+    config.headers['X-XSRF-TOKEN'] = getCookieValue('XSRF-TOKEN')
 
-// import Echo from 'laravel-echo';
-
-// window.Pusher = require('pusher-js');
-
-// window.Echo = new Echo({
-//     broadcaster: 'pusher',
-//     key: process.env.MIX_PUSHER_APP_KEY,
-//     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
-//     forceTLS: true
-// });
+    return config
+})

--- a/resources/js/store/auth.js
+++ b/resources/js/store/auth.js
@@ -1,0 +1,15 @@
+const state = {}
+
+const getters = {}
+
+const mutations = {}
+
+const actions = {}
+
+export default {
+    namespaced: true,
+    state,
+    getters,
+    mutations,
+    actions
+}

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -1,0 +1,14 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+import auth from './auth'
+
+Vue.use(Vuex)
+
+const store = new Vuex.Store({
+    modules: {
+        auth
+    }
+})
+
+export default store

--- a/resources/js/util.js
+++ b/resources/js/util.js
@@ -1,0 +1,21 @@
+/**
+ * クッキーの値を取得する
+ * @param {String} searchKey 検索するキー
+ * @returns {String} キーに対応する値
+ */
+export function getCookieValue(searchKey) {
+    if (typeof searchKey === 'undefined') {
+        return ''
+    }
+
+    let val = ''
+
+    document.cookie.split(';').forEach(cookie => {
+        const [key, value] = cookie.split('=')
+        if (key === searchKey) {
+            return val = value
+        }
+    })
+
+    return val
+}


### PR DESCRIPTION
# 概要
Vuexを用いてvueコンポーネント間でデータ操作を行う
Ajaxのapi通信のため、XSRF認証はフォームではなくヘッダーで認証を行う

# 対応
- Vuexのインストール
- 認証用のストアモジュール仮作成
- ストアの登録
- Keyを指定したCookieの値を取得するUtil関数作成
- ajax実行時に、headerの中にXSRF用のトークンを付与する実装作成