### PR TITLE
写真の詳細ページを作成

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -54,4 +54,9 @@ class PhotoController extends Controller
 
         return response($download_file['file'], 200, $headers);
     }
+
+    public function show(String $photo_id)
+    {
+        return Photo::where('id', $photo_id)->with(['user'])->firstOrFail();
+    }
 }

--- a/resources/js/pages/PhotoDetail.vue
+++ b/resources/js/pages/PhotoDetail.vue
@@ -1,6 +1,13 @@
 <template>
-  <div v-if="photo" class="photo-detail">
-    <figure class="photo-detail__pane photo-detail__image">
+  <div
+    v-if="photo"
+    class="photo-detail"
+    :class="{ 'photo-detail--column': fullWidth }"
+  >
+    <figure
+      class="photo-detail__pane photo-detail__image"
+      @click="fullWidth = !fullWidth"
+    >
       <img :src="photo.url" alt="" />
       <figcaption>Posted by {{ photo.user.name }}</figcaption>
     </figure>
@@ -35,6 +42,7 @@ export default {
   data() {
     return {
       photo: null,
+      fullWidth: false,
     };
   },
   methods: {

--- a/resources/js/pages/PhotoDetail.vue
+++ b/resources/js/pages/PhotoDetail.vue
@@ -1,3 +1,61 @@
 <template>
-  <h1>Photo Detail</h1>
+  <div v-if="photo" class="photo-detail">
+    <figure class="photo-detail__pane photo-detail__image">
+      <img :src="photo.url" alt="" />
+      <figcaption>Posted by {{ photo.user.name }}</figcaption>
+    </figure>
+    <div class="photo-detail__pane">
+      <button class="button button--like" title="Like photo">
+        <i class="icon ion-md-heart"></i>12
+      </button>
+      <a
+        :href="`/photos/${photo.id}/download`"
+        class="button"
+        title="Download photo"
+      >
+        <i class="icon ion-md-arrow-round-down"></i>Download
+      </a>
+      <h2 class="photo-detail__title">
+        <i class="icon ion-md-chatboxes"></i>Comments
+      </h2>
+    </div>
+  </div>
 </template>
+
+<script>
+import { OK } from "../util";
+
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      photo: null,
+    };
+  },
+  methods: {
+    async fetchPhoto() {
+      const response = await axios.get(`/api/photos/${this.id}`);
+
+      if (response.status !== OK) {
+        this.$store.commit("error/setCode", response.status);
+        return false;
+      }
+
+      this.photo = response.data;
+    },
+  },
+  watch: {
+    $route: {
+      async handler() {
+        await this.fetchPhoto();
+      },
+      immediate: true,
+    },
+  },
+};
+</script>

--- a/resources/js/pages/PhotoDetail.vue
+++ b/resources/js/pages/PhotoDetail.vue
@@ -34,7 +34,7 @@ import { OK } from "../util";
 
 export default {
   props: {
-    id: {
+    photo_id: {
       type: String,
       required: true,
     },
@@ -47,7 +47,7 @@ export default {
   },
   methods: {
     async fetchPhoto() {
-      const response = await axios.get(`/api/photos/${this.id}`);
+      const response = await axios.get(`/photos/${this.photo_id}`);
 
       if (response.status !== OK) {
         this.$store.commit("error/setCode", response.status);

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -19,7 +19,7 @@ const routes = [
         }
     },
     {
-        path: '/photos/:id',
+        path: '/photos/:photo_id',
         component: PhotoDetail,
         props: true
     },

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ Route::group(['middleware' => 'auth'], function () {
 });
 
 Route::get('/photos', 'PhotoController@index')->name('photo.index');
+Route::get('/photos/{photo_id}', 'PhotoController@show')->name('photo.show');
 Route::get('/photos/{photo_id}/download', 'PhotoController@download');
 
 Route::get('/{any?}', fn () => view('index'))->where('any', '.+');

--- a/tests/Http/Controllers/PhotoControllerTest.php
+++ b/tests/Http/Controllers/PhotoControllerTest.php
@@ -76,4 +76,36 @@ class PhotoControllerTest extends TestCase
 
         $response->assertStatus(200);
     }
+
+    /** @test */
+    public function should_ステータスコード200が返る()
+    {
+        factory(Photo::class)->create();
+        $photo = Photo::first();
+        $response = $this->json('GET', route('photo.show', [
+            'id' => $photo->id,
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    /** @test */
+    public function should_詳細写真のJSONを返却する()
+    {
+        factory(Photo::class)->create();
+        $photo = Photo::first();
+        $response = $this->json('GET', route('photo.show', [
+            'id' => $photo->id,
+        ]));
+
+        $response->assertJsonFragment(
+            [
+                'id' => $photo->id,
+                'url' => $photo->url,
+                'owner' => [
+                    'name' => $photo->owner->name,
+                ],
+            ]
+        );
+    }
 }

--- a/tests/Http/Controllers/PhotoControllerTest.php
+++ b/tests/Http/Controllers/PhotoControllerTest.php
@@ -83,7 +83,7 @@ class PhotoControllerTest extends TestCase
         factory(Photo::class)->create();
         $photo = Photo::first();
         $response = $this->json('GET', route('photo.show', [
-            'id' => $photo->id,
+            'photo_id' => $photo->id,
         ]));
 
         $response->assertStatus(200);
@@ -95,15 +95,15 @@ class PhotoControllerTest extends TestCase
         factory(Photo::class)->create();
         $photo = Photo::first();
         $response = $this->json('GET', route('photo.show', [
-            'id' => $photo->id,
+            'photo_id' => $photo->id,
         ]));
 
         $response->assertJsonFragment(
             [
                 'id' => $photo->id,
                 'url' => $photo->url,
-                'owner' => [
-                    'name' => $photo->owner->name,
+                'user' => [
+                    'name' => $photo->user->name,
                 ],
             ]
         );


### PR DESCRIPTION
# 概要
一覧ページに有る写真をクリックすると、その写真の詳細ページを表示する

## 対応したこと
- 画像を表示
- ダウンロードのボタンを追加
- いいねボタンを仮置で追加
- コメントのエリアを仮置で追加
- 画像をクリックすると、画像を拡大するように実装