### PR TITLE
写真投稿後、投稿した写真の詳細画面に遷移する

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -32,8 +32,8 @@ class PhotoController extends Controller
     public function create(StorePhoto $request, PhotoPostingUseCase $usecase)
     {
         $uploaded_file = $request->file('photo');
-        $usecase->execute($uploaded_file);
-        return response('', 201);
+        $add_photo_id = $usecase->execute($uploaded_file);
+        return response(['add_photo_id' => $add_photo_id], 201);
     }
 
     /**

--- a/app/UseCases/PhotoPostingUseCase.php
+++ b/app/UseCases/PhotoPostingUseCase.php
@@ -18,5 +18,7 @@ class PhotoPostingUseCase
         DB::transaction(function () use ($photo) {
             Auth::user()->photos()->save($photo);
         });
+
+        return $photo->id;
     }
 }

--- a/resources/js/components/PhotoForm.vue
+++ b/resources/js/components/PhotoForm.vue
@@ -105,7 +105,7 @@ export default {
         timeout: 6000,
       })
 
-      this.$router.push(`/photos/${response.data.id}`)
+      this.$router.push(`/photos/${response.data.add_photo_id}/`)
     },
   },
 }

--- a/tests/Http/Controllers/PhotoControllerTest.php
+++ b/tests/Http/Controllers/PhotoControllerTest.php
@@ -33,6 +33,19 @@ class PhotoControllerTest extends TestCase
     }
 
     /** @test */
+    public function create_追加された写真のIDがjsonデータに含まれている()
+    {
+        Storage::fake('s3');
+
+        $response = $this->actingAs($this->user)
+            ->json('POST', route('photo.create'), [
+                'photo' => UploadedFile::fake()->image('photo.jpg')
+            ]);
+
+        $this->assertNotNull($response->json()['add_photo_id']);
+    }
+
+    /** @test */
     public function index_ステータス200が返る()
     {
         $response = $this->json('GET', route('photo.index'));

--- a/tests/UseCases/PhotoPostingUseCaseTest.php
+++ b/tests/UseCases/PhotoPostingUseCaseTest.php
@@ -54,4 +54,13 @@ class PhotoPostingUseCaseTest extends TestCase
         $this->usecase->execute($this->image_file);
         $this->assertRegExp('/^[0-9a-zA-Z-_]{12}$/', Photo::first()->id);
     }
+
+    /** @test */
+    public function photoテーブルに追加されたIDを返す()
+    {
+        $user = factory(User::class)->create();
+        $this->actingAs($user);
+        $id = $this->usecase->execute($this->image_file);
+        $this->assertEquals(Photo::first()->id, $id);
+    }
 }


### PR DESCRIPTION
# 概要
写真を投稿したあと、投稿した写真の詳細画面に遷移するよう変更

# 対応
- UseCaseで保存した写真レコードのIDを返却する
- Controllerで受け取ったIDをJson形式で返却する
- VueでPOSTして返却されたレスポンスから、IDを取得し詳細画面に遷移する
